### PR TITLE
Db to mongo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,7 @@
 ## Tech
 *   D3
 *   Mongo?
+
+
+## Dependecies
+*  

--- a/trail_tracker/api/views.py
+++ b/trail_tracker/api/views.py
@@ -15,9 +15,8 @@ class ListTrailsViewSet(viewsets.ModelViewSet):
     # queryset = Trail.objects.all()
     serializer_class = TrailSerializer
     lookup_field = 'name'
-
     def get_queryset(self):
         query = Trail.objects.all()
 
-        print self.request
+        print(self.request)
         return query

--- a/trail_tracker/rides/models.py
+++ b/trail_tracker/rides/models.py
@@ -4,8 +4,8 @@ from __future__ import unicode_literals
 from django.db import models
 
 # Create your models here.
-class Ride(models.Model):
-    """
-    Ride data including desc, serialized GPS data, and foreign
-    key relationsips to Trail (eventually) bike
-    """
+# class Ride(models.Model):
+#     """
+#     Ride data including desc, serialized GPS data, and foreign
+#     key relationsips to Trail (eventually) bike
+#     """

--- a/trail_tracker/settings.py
+++ b/trail_tracker/settings.py
@@ -10,12 +10,13 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/1.11/ref/settings/
 """
 
+import dotenv
 import os
-from dotenv import load_dotenv, find_dotenv
 from mongoengine import connect
 
 # Find and load environment variables
-load_dotenv(find_dotenv())
+dotenv.read_dotenv()
+
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/trail_tracker/settings.py
+++ b/trail_tracker/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/1.11/ref/settings/
 
 import os
 from dotenv import load_dotenv, find_dotenv
+from mongoengine import connect
 
 # Find and load environment variables
 load_dotenv(find_dotenv())
@@ -97,15 +98,15 @@ WSGI_APPLICATION = 'trail_tracker.wsgi.application'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.mysql',
+        'ENGINE': 'django.db.backends.dummy',
         'NAME': 'trails',
-        'USER': os.environ.get('DB_USER'),
-        'PASSWORD': os.environ.get('DB_PASSWORD'),
+        'USER': os.environ.get('DB_USER'),'PASSWORD': os.environ.get('DB_PASSWORD'),
         'HOST': os.environ.get('DB_HOST'),
         'PORT': os.environ.get('DB_PORT'),
     }
 }
 
+connect('trails', username=os.environ.get('DB_USER'), password=os.environ.get('DB_PASSWORD'))
 
 # Password validation
 # https://docs.djangoproject.com/en/1.11/ref/settings/#auth-password-validators

--- a/trail_tracker/trails/models.py
+++ b/trail_tracker/trails/models.py
@@ -2,22 +2,24 @@
 from __future__ import unicode_literals
 
 from django.conf import settings
-from django.db import models
+# from django.db import models
+from mongoengine import *
 from django.utils.translation import ugettext_lazy as _
 
-class Trail(models.Model):
+class Trail(Document):
     """
     Trail model references IRL trails
     """
 
-    name = models.CharField(_('name'), max_length=settings.TRAIL_NAME_MAX_LENGTH, default='')
-    city = models.CharField(_('city'), max_length=settings.DEFAULT_MODEL_FIELD_LENGTH, default='')
-    state = models.CharField(_('state'), max_length=2, default='')
-    country = models.CharField(_('country'), max_length=settings.DEFAULT_MODEL_FIELD_LENGTH, default='US')
+    question = StringField(max_length=200)
+    # CharField(_('name'), max_length=settings.TRAIL_NAME_MAX_LENGTH, default='')
+    # CharField(_('city'), max_length=settings.DEFAULT_MODEL_FIELD_LENGTH, default='')
+    # CharField(_('state'), max_length=2, default='')
+    # CharField(_('country'), max_length=settings.DEFAULT_MODEL_FIELD_LENGTH, default='US')
 
     # GPS location of trailhead
-    lat = models.FloatField(_('latitude'), default='')
-    lon = models.FloatField(_('longitude'), default='')
+    # FloatField(_('latitude'), default='')
+    # FloatField(_('longitude'), default='')
 
     @classmethod
     def create(cls, name='test', city='Boston', state='MA',

--- a/trail_tracker/trails/views.py
+++ b/trail_tracker/trails/views.py
@@ -14,5 +14,4 @@ class ListTrailsView(ListView):
     template_name= 'trails/trails_list.html'
 
     def render_to_response(self, request):
-        print dir(self)
         return super(ListTrailsView, self).render_to_response( request)


### PR DESCRIPTION
This changes the primary database over to MongoDB. Uses [mongoengine](http://mongoengine.org/) as DOM.

After meeting with the team, we have decided that based to undefined needs (read models), the ability to adjust models without having to fux with migrations warrants the use of a non-relational database. MongoDB was the obvious choice given all of the team's previous experience.

## Important Notes
* Take care to note that all Django models now inherit from `mongoengine.Document`.